### PR TITLE
corrigindo tamanho dos icons do alert component

### DIFF
--- a/src/components/Alert/Alert.module.css
+++ b/src/components/Alert/Alert.module.css
@@ -8,7 +8,6 @@
     justify-content: space-between;
     gap: 20px;
     height: fit-content;
-    width: 400px;
     padding: 10px;
 }
 
@@ -34,4 +33,10 @@
 
 .data{
     font-size: 11px;
+}
+
+.icon{
+    object-fit: contain;
+    height: 25px;
+    width: 25px;
 }

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -24,16 +24,15 @@ function normalize(str: string) {
     return str.toLowerCase();
 }
 
-function Alert({ titulo, descricao, data, largura = '1000px' }: AlertProps) {
+//Por padrão esse componente tem 400px de largura, mas dá pra passar um valor diferente via props
+function Alert({ titulo, descricao, data, largura = '400px' }: AlertProps) {
     const normalizedTitle = normalize(titulo);
-    const icon = iconMap[normalizedTitle] || warning;
+    const icon = iconMap[normalizedTitle];
 
     return (
         <div className={styles.aviso} style={{ width: largura }}>
             <div className={styles.conteudoPrincipal}>
-                <div className={styles.icon}>
-                    <img src={icon} alt={`Ícone para ${titulo}`} />
-                </div>
+                <img className={styles.icon} src={icon} alt={`Ícone para ${titulo}`} />
                 <div className={styles.texto}>
                     <p className={styles.titulo}>{titulo}</p>
                     <p className={styles.descricao}>{descricao}</p>


### PR DESCRIPTION
FIX:

No código anterior os icons do Alert component eram mostrados com tamanhos distintos, de acordo com a quantidade de texto contida no componente. Essa correção simples tornou fixos os tamanhos dos icons para evitar esse problema.