### PR TITLE
fix: footer na página de cadastro de edital

### DIFF
--- a/src/pages/paginaProae/CadastroEdital/CadastroEdital.css
+++ b/src/pages/paginaProae/CadastroEdital/CadastroEdital.css
@@ -1,11 +1,11 @@
 .cadastro-page {
-    /*display: flex;*/
-    /*flex-direction: column;*/
-    /*height: 100vh;*/
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
 .steps-container {
-    display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
 }
@@ -30,7 +30,6 @@
     height: 8vh;
     padding: 0 4rem;
     border-top: 1px solid #14374c4f;
-    bottom: 0;
     background-color: var(--cor-creme);
     z-index: 10;
 }

--- a/src/pages/paginaProae/CadastroEdital/CadastroEdital.tsx
+++ b/src/pages/paginaProae/CadastroEdital/CadastroEdital.tsx
@@ -1,10 +1,10 @@
-import Steps, {StepsConfig} from "@/components/Steps/Steps.tsx";
+import Steps, { StepsConfig } from "@/components/Steps/Steps.tsx";
 import logoUfba from "../../../assets/logo-ufba.png";
 import InputGroup from "@/components/InputGroup/InputGroup.tsx";
-import {FormProvider, useForm} from "react-hook-form";
-import CustomInput, {InputProps} from "@/components/CustomInput/CustomInput.tsx";
+import { FormProvider, useForm } from "react-hook-form";
+import CustomInput, { InputProps } from "@/components/CustomInput/CustomInput.tsx";
 import { TypeInput } from "@/utils/enumInput.tsx";
-// import arrowDownIcon from "../../../assets/icons/arrow-down-item.svg";
+import arrowDownIcon from "../../../assets/icons/arrow-down-item.svg";
 import { useNavigate } from "react-router-dom";
 import "./CadastroEdital.css";
 
@@ -18,48 +18,48 @@ const CadastroEdital = () => {
     const navigate = useNavigate();
 
     const inputsOfDetailsStep: InputProps[] = [
-            { name: "nome_edital", type: TypeInput.Text, title: "Nome do edital", placeholder: "Seleção para benefícios PROAE", required: true},
-            { name: "descricao", type: TypeInput.Text, title: "Descrição do edital", placeholder: "Descreva o edital", required: true },
-            { name: "tipo_do_beneficio", type: TypeInput.Text, title: "Tipo do benefício do edital", placeholder: "Alimentação", required: true },
-            { name: "quantidade_bolsas", type: TypeInput.Text, title: "Quantidade de bolsas", placeholder: "15", required: true}];
+        { name: "nome_edital", type: TypeInput.Text, title: "Nome do edital", placeholder: "Seleção para benefícios PROAE", required: true },
+        { name: "descricao", type: TypeInput.Text, title: "Descrição do edital", placeholder: "Descreva o edital", required: true },
+        { name: "tipo_do_beneficio", type: TypeInput.Text, title: "Tipo do benefício do edital", placeholder: "Alimentação", required: true },
+        { name: "quantidade_bolsas", type: TypeInput.Text, title: "Quantidade de bolsas", placeholder: "15", required: true }];
 
-    const inputDetailsProps = {inputsConfig: inputsOfDetailsStep}
+    const inputDetailsProps = { inputsConfig: inputsOfDetailsStep }
 
-    const inputDocProps: InputProps = { name: "edital_url", type: TypeInput.TextWithPlusButton, title: "Link para o documento do edital", placeholder: "Link", required: true};
+    const inputDocProps: InputProps = { name: "edital_url", type: TypeInput.TextWithPlusButton, title: "Link para o documento do edital", placeholder: "Link", required: true };
 
     const inputOfEtapasEditalStep: InputProps[] = [
-        { name: "primeiraEtapa", type: TypeInput.TextWithCalendar, title: "Primeira etapa", placeholder: "Nome primeira etapa", required: true},
-        { name: "meioEtapas", type: TypeInput.TextWithCalendarRange, title: "Etapa", placeholder: "Nome etapa", required: true},
-        { name: "ultimaEtapa", type: TypeInput.TextWithCalendar, title: "Ultima etapa", placeholder: "Nome ultima etapa", required: true}
+        { name: "primeiraEtapa", type: TypeInput.TextWithCalendar, title: "Primeira etapa", placeholder: "Nome primeira etapa", required: true },
+        { name: "meioEtapas", type: TypeInput.TextWithCalendarRange, title: "Etapa", placeholder: "Nome etapa", required: true },
+        { name: "ultimaEtapa", type: TypeInput.TextWithCalendar, title: "Ultima etapa", placeholder: "Nome ultima etapa", required: true }
     ];
 
-    const inputEtapasEdital = {inputsConfig: inputOfEtapasEditalStep}
+    const inputEtapasEdital = { inputsConfig: inputOfEtapasEditalStep }
 
     const steps: StepsConfig[] = [
-        {stepTitle: "Olá Caio! Vamos cadastrar o processo seletivo?", stepSubtitle: "Você está começando as etapas para cadastrar um novo edital.",nextButtonName: "Continuar", isFirstPage: true, logoSrc: logoUfba},
-        {stepTitle: "Detalhes", stepSubtitle: "Cadastre os detalhes do edital.", backButtonName: "Voltar", nextButtonName: "Continuar", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: InputGroup, stepDynamicProps: inputDetailsProps},
-        {stepTitle: "Documentos", stepSubtitle: "Cadastre os links dos documentos do edital", backButtonName: "Voltar", nextButtonName: "Continuar", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: CustomInput, stepDynamicProps: inputDocProps},
-        {stepTitle: "Etapas do edital", stepSubtitle: "Cadastre as etapas do edital para a fácil consulta dos alunos na tela de inscrições.", backButtonName: "Voltar", nextButtonName: "Salvar Edital", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: InputGroup, stepDynamicProps: inputEtapasEdital, isLastPage: true}];
+        { stepTitle: "Olá Caio! Vamos cadastrar o processo seletivo?", stepSubtitle: "Você está começando as etapas para cadastrar um novo edital.", nextButtonName: "Continuar", isFirstPage: true, logoSrc: logoUfba },
+        { stepTitle: "Detalhes", stepSubtitle: "Cadastre os detalhes do edital.", backButtonName: "Voltar", nextButtonName: "Continuar", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: InputGroup, stepDynamicProps: inputDetailsProps },
+        { stepTitle: "Documentos", stepSubtitle: "Cadastre os links dos documentos do edital", backButtonName: "Voltar", nextButtonName: "Continuar", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: CustomInput, stepDynamicProps: inputDocProps },
+        { stepTitle: "Etapas do edital", stepSubtitle: "Cadastre as etapas do edital para a fácil consulta dos alunos na tela de inscrições.", backButtonName: "Voltar", nextButtonName: "Salvar Edital", isNextButtonEnabled: methods.formState.isValid, StepDynamicComponent: InputGroup, stepDynamicProps: inputEtapasEdital, isLastPage: true }];
 
     return (
         <div className="cadastro-page">
             <div className="header">
-                <div className="logo" onClick={() => navigate("/portal-proae/inscricoes")} style={{cursor: "pointer"}}>
+                <div className="logo" onClick={() => navigate("/portal-proae/inscricoes")} style={{ cursor: "pointer" }}>
                     <h1>PROAE</h1>
                 </div>
                 <p className="details">Cadastro de Edital PROAE</p>
             </div>
             <div className="steps-container">
                 <FormProvider {...methods}>
-                    <Steps stepsConfig={steps} whereToRedirectWhenFinishSteps={"/portal-proae/processos"}/>
+                    <Steps stepsConfig={steps} whereToRedirectWhenFinishSteps={"/portal-proae/processos"} />
                 </FormProvider>
             </div>
-            {/*<div className="footer">*/}
-            {/*    <div className="footer-back" onClick={goToHome}>*/}
-            {/*        <img src={arrowDownIcon} className="arrow-down" alt="Cancelar"/>*/}
-            {/*        <span className="voltar-texto">Cancelar</span>*/}
-            {/*    </div>*/}
-            {/*</div>*/}
+            <div className="footer">
+                <div className="footer-back" onClick={() => navigate("/")} style={{ cursor: "pointer" }}>
+                    <img src={arrowDownIcon} className="arrow-down" alt="Cancelar" />
+                    <span className="voltar-texto">Cancelar</span>
+                </div>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
Mudanças no css da página de cadastro para acomodar o footer que não estava se comportando corretamente. Agora o footer está posicionado no fim da página e o botão de cancelar redireciona para a home page.